### PR TITLE
Update build.yaml

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -30,5 +30,4 @@ include:
     shield: settings_reset
   - board: nice_nano_v2
     shield: cygnus_central_dongle dongle_display
-    cmake-args: -DCONFIG_ZMK_USB_LOGGING=y
     artifact-name: cygnus_central_dongle_with_logging


### PR DESCRIPTION
ZMKファームウェアのビルド中エラー
warning: USB_CDC_ACM (...) has direct dependencies SERIAL && DT_HAS_ZEPHYR_CDC_ACM_UART_ENABLED && USB_DEVICE_STACK with value n, but is currently being y-selected by the following symbols:
 - ZMK_USB_LOGGING (...), with value y

warning: UART_CONSOLE (...) has direct dependencies SERIAL && SERIAL_HAS_DRIVER && CONSOLE with value n, but is currently being y-selected by the following symbols:
 - ZMK_USB_LOGGING (...), with value y

warning: UART_INTERRUPT_DRIVEN (...) has direct dependencies (...) with value n, but is currently being y-selected by the following symbols:
 - ZMK_USB_LOGGING (...), with value y

error: Aborting due to Kconfig warnings

に対して、

cmake-args: -DCONFIG_ZMK_USB_LOGGING=y

を削除